### PR TITLE
fix: PAC pointer signing incorrectly gated on AArch64 alone (breaks non-Darwin targets); StringEncryption misses Rust byte-string constants

### DIFF
--- a/llvm/lib/Transforms/Obfuscation/IndirectBranch.cpp
+++ b/llvm/lib/Transforms/Obfuscation/IndirectBranch.cpp
@@ -197,7 +197,13 @@ struct IndirectBranch : public FunctionPass {
         buildDecrypt.FuncKey = FuncKeys[AddrTBB];
         buildDecrypt.PtrEncKey = PtrEncKey;
         Triple T(M.getTargetTriple());
-        buildDecrypt.PtrAuthKey = T.isAArch64() ? 0 : -1;
+        // PAC pointer signing is an Apple arm64e ABI feature, not a generic
+        // AArch64 one - AArch64-but-not-Darwin targets (e.g. Android) don't
+        // enable the `+pauth` subtarget feature by default, so emitting
+        // llvm.ptrauth.sign unconditionally for every AArch64 triple hits
+        // "Cannot select: intrinsic %llvm.ptrauth.sign" in the instruction
+        // selector on those targets.
+        buildDecrypt.PtrAuthKey = (T.isAArch64() && T.isOSDarwin()) ? 0 : -1;
         buildDecrypt.PtrAuthDisc = 0;
 
         auto            TargetPtr = buildPageTableDecryptIR(buildDecrypt);

--- a/llvm/lib/Transforms/Obfuscation/IndirectCall.cpp
+++ b/llvm/lib/Transforms/Obfuscation/IndirectCall.cpp
@@ -211,7 +211,9 @@ struct IndirectCall : public FunctionPass {
         buildDecrypt.ModuleKey = CalleeKeys[Callee];
         buildDecrypt.FuncKey = FuncKeys[Callee];
         buildDecrypt.PtrEncKey = PtrEncKey;
-        buildDecrypt.PtrAuthKey = T.isAArch64() ? 0 : -1;
+        // PAC signing is an Apple arm64e ABI feature, not generic AArch64 -
+        // see IndirectBranch.cpp's comment on this same pattern.
+        buildDecrypt.PtrAuthKey = (T.isAArch64() && T.isOSDarwin()) ? 0 : -1;
         buildDecrypt.PtrAuthDisc = 0;
         auto        DecPtr = buildPageTableDecryptIR(buildDecrypt);
         IRBuilder<> SIB(DecryptPt);
@@ -255,7 +257,9 @@ struct IndirectCall : public FunctionPass {
         buildDecrypt.FuncKey = FuncKeys[Callee];
         buildDecrypt.PtrEncKey = PtrEncKey;
         Triple T(M.getTargetTriple());
-        buildDecrypt.PtrAuthKey = T.isAArch64() ? 0 : -1;
+        // PAC signing is an Apple arm64e ABI feature, not generic AArch64 -
+        // see IndirectBranch.cpp's comment on this same pattern.
+        buildDecrypt.PtrAuthKey = (T.isAArch64() && T.isOSDarwin()) ? 0 : -1;
         buildDecrypt.PtrAuthDisc = 0;
         auto FnPtr = buildPageTableDecryptIR(buildDecrypt);
         FnPtr->setName("Call_" + Callee->getName());

--- a/llvm/lib/Transforms/Obfuscation/IndirectGlobalVariable.cpp
+++ b/llvm/lib/Transforms/Obfuscation/IndirectGlobalVariable.cpp
@@ -207,7 +207,9 @@ struct IndirectGlobalVariable : public FunctionPass {
         buildDecrypt.ModuleKey = GVKeys[GV];
         buildDecrypt.FuncKey = FuncKeys[GV];
         buildDecrypt.PtrEncKey = PtrEncKey;
-        buildDecrypt.PtrAuthKey = T.isAArch64() ? 2 : -1;
+        // PAC signing is an Apple arm64e ABI feature, not generic AArch64 -
+        // see IndirectBranch.cpp's comment on this same pattern.
+        buildDecrypt.PtrAuthKey = (T.isAArch64() && T.isOSDarwin()) ? 2 : -1;
         buildDecrypt.PtrAuthDisc = 0;
         auto        GVPtr = buildPageTableDecryptIR(buildDecrypt);
         IRBuilder<> SIB(DecryptPt);
@@ -255,7 +257,9 @@ struct IndirectGlobalVariable : public FunctionPass {
             buildDecrypt.FuncKey = FuncKeys[GV];
             buildDecrypt.PtrEncKey = PtrEncKey;
             Triple T(M.getTargetTriple());
-            buildDecrypt.PtrAuthKey = T.isAArch64() ? 2 : -1;
+            // PAC signing is an Apple arm64e ABI feature, not generic AArch64 -
+            // see IndirectBranch.cpp's comment on this same pattern.
+            buildDecrypt.PtrAuthKey = (T.isAArch64() && T.isOSDarwin()) ? 2 : -1;
             buildDecrypt.PtrAuthDisc = 0;
             GVPtr = buildPageTableDecryptIR(buildDecrypt);
           }

--- a/llvm/lib/Transforms/Obfuscation/StringEncryption.cpp
+++ b/llvm/lib/Transforms/Obfuscation/StringEncryption.cpp
@@ -163,6 +163,35 @@ bool StringEncryption::runOnModule(Module &M) {
         ConstantStringPool.push_back(Entry);
         CSPEntryMap[&GV] = Entry;
         collectConstantStringUser(&GV, ConstantStringUsers);
+      } else if (CDS->getElementType()->isIntegerTy(8)) {
+        // Rust (and other non-C-ABI) byte-string constants are not
+        // NUL-terminated (length is carried separately in a fat pointer),
+        // so isCString() is always false for them even though they're
+        // exactly the kind of literal this pass exists to protect. The
+        // encrypt/decrypt logic below is purely length-based (it never
+        // relies on a trailing NUL), so it's safe to treat any i8 constant
+        // array the same way as a C string.
+        CSPEntry *Entry = new CSPEntry();
+        Entry->IsUTF16 = false;
+        StringRef Data = CDS->getRawDataValues();
+        Entry->Data.reserve(Data.size());
+        for (unsigned i = 0; i < Data.size(); ++i) {
+          Entry->Data.push_back(static_cast<uint8_t>(Data[i]));
+        }
+        Entry->ID = static_cast<unsigned>(ConstantStringPool.size());
+        Constant *      ZeroInit = Constant::getNullValue(CDS->getType());
+        GlobalVariable *DecGV = new GlobalVariable(
+            M, CDS->getType(), false, GlobalValue::PrivateLinkage,
+            ZeroInit, "dec" + Twine::utohexstr(Entry->ID) + GV.getName());
+        GlobalVariable *DecStatus = new GlobalVariable(
+            M, Type::getInt32Ty(Ctx), false, GlobalValue::PrivateLinkage,
+            Zero, "dec_status_" + Twine::utohexstr(Entry->ID) + GV.getName());
+        DecGV->setAlignment(GV.getAlign());
+        Entry->DecGV = DecGV;
+        Entry->DecStatus = DecStatus;
+        ConstantStringPool.push_back(Entry);
+        CSPEntryMap[&GV] = Entry;
+        collectConstantStringUser(&GV, ConstantStringUsers);
       } else {
         // treat arrays of i16 as UTF-16 constant strings
         Type *EltTy = CDS->getElementType();


### PR DESCRIPTION
## Summary

Fixes two issues found while building this toolchain for an Android
(non-Darwin AArch64) target:

1. **PAC pointer signing was being enabled for all AArch64 targets,
   not just Apple arm64e.** IndirectBranch.cpp / IndirectCall.cpp /
   IndirectGlobalVariable.cpp all gated PtrAuthKey on T.isAArch64()
   alone. PAC (pointer authentication) signing is an Apple arm64e ABI
   feature — generic AArch64 targets such as Android don't enable the
   +pauth subtarget feature, so emitting llvm.ptrauth.sign
   unconditionally hits "Cannot select: intrinsic %llvm.ptrauth.sign"
   in the instruction selector. Fixed by additionally checking
   T.isOSDarwin().

2. **StringEncryption.cpp's isCString() check misses non-NUL-terminated
   byte-string constants** (e.g. Rust &[u8]/byte-string literals, which
   carry their length via a separate fat pointer instead of a NUL
   terminator). These are exactly the kind of literal this pass exists
   to protect, but were silently skipped. Added a branch that treats
   any i8 constant array the same way, since the encrypt/decrypt logic
   is purely length-based and never relies on a trailing NUL.

## Test plan

- Rebuilt with --irobf-indbr/--irobf-icall/--irobf-indgv enabled,
  confirmed all 7 obfuscation flags now build cleanly for an
  aarch64-linux-android Rust target (previously hit the PAC selection
  failure).
- Confirmed Rust byte-string constants are now covered by --irobf-cse
  (previously left in plaintext in the object file).
