### PR TITLE
fix: disable optimization for AArch64Subtarget.cpp under MSVC (pathological compile time)

### DIFF
--- a/llvm/lib/Target/AArch64/CMakeLists.txt
+++ b/llvm/lib/Target/AArch64/CMakeLists.txt
@@ -123,6 +123,10 @@ add_llvm_target(AArch64CodeGen
   AArch64
   )
 
+if (MSVC)
+  set_source_files_properties(AArch64Subtarget.cpp PROPERTIES COMPILE_OPTIONS "/Od")
+endif()
+
 add_subdirectory(AsmParser)
 add_subdirectory(Disassembler)
 add_subdirectory(MCTargetDesc)


### PR DESCRIPTION
## Summary

MSVC's optimizer (`/O2`, the default under a Release `CMAKE_BUILD_TYPE`)
enters what is effectively a hang compiling `AArch64Subtarget.cpp` -
reproduced multiple times: CPU time barely advances over many minutes
(observed 25+ minutes, memory usage flat around 494MB) while wall-clock
time keeps climbing. Killing the process and recompiling the exact same
command line with `/O2 /Ob2` replaced by `/Od` succeeds immediately.

Likely culprit (not fully root-caused, but a strong structural
candidate): `AArch64Subtarget::initializeProperties()` contains a single
~220-line `switch` over `ARMProcFamily` with dozens of CPU-tuning cases,
each setting several subtarget feature fields - a known pattern for
MSVC's optimizer to struggle with under aggressive inlining/constant
propagation.

Scoped to MSVC only via `if (MSVC)` - no effect on GCC/Clang builds
(e.g. on Linux).

## Test plan

- Reproduced the hang on a clean build (Visual Studio 2022, MSVC
  14.44.35207) - `ninja` stuck on this single translation unit while
  4568/4614 other targets had already completed.
- Confirmed `/Od` on just this file lets the build proceed and complete
  normally; the rest of the target compiles at normal optimization
  levels as before.

## Caveat

I only reproduced this on one machine/toolchain combination (Windows 11,
Visual Studio 2022 / MSVC 14.44.35207). If this doesn't reproduce in your
environment, or you'd rather investigate the actual root cause in
`initializeProperties()` instead of working around it, feel free to close
this without merging - I don't have strong confidence this generalizes
beyond what I saw.
